### PR TITLE
FE-Fix: 색상 필터링 옵션 오류 코드 수정 #24

### DIFF
--- a/client/src/components/search/filterOption/FilterOption.tsx
+++ b/client/src/components/search/filterOption/FilterOption.tsx
@@ -1,7 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../../store';
 import { toggleSelection } from '../../../store/slices/filterSlice';
-import { TbSquareRoundedFilled } from 'react-icons/tb';
 
 interface FilterOptionProps {
   label: string;
@@ -23,6 +22,8 @@ const FilterOption: React.FC<FilterOptionProps> = ({
     (state: RootState) => state.filter[field] === value
   );
 
+  const iconStyle = color ? { color } : {};
+
   return (
     <div
       onClick={() => dispatch(toggleSelection({ field, value }))}
@@ -30,9 +31,7 @@ const FilterOption: React.FC<FilterOptionProps> = ({
       role="button"
       aria-label={label}
     >
-      <Icon
-        className={`text-3xl ${Icon === TbSquareRoundedFilled ? `text-${color}` : ''}`}
-      />
+      <Icon className="text-3xl" style={iconStyle} />
       {label}
     </div>
   );

--- a/client/src/components/search/filterOption/SelectedColor.tsx
+++ b/client/src/components/search/filterOption/SelectedColor.tsx
@@ -1,4 +1,8 @@
-import { TbSquareRoundedFilled } from 'react-icons/tb';
+import {
+  TbHelpSquareRoundedFilled,
+  TbSquareRounded,
+  TbSquareRoundedFilled,
+} from 'react-icons/tb';
 import FilterOption from './FilterOption';
 
 const SelectedColor = () => {
@@ -11,56 +15,56 @@ const SelectedColor = () => {
           icon={TbSquareRoundedFilled}
           field="selectedColor"
           value="분홍"
-          color="pink-500"
+          color="pink"
         />
         <FilterOption
           label="빨강"
           icon={TbSquareRoundedFilled}
           field={'selectedColor'}
           value="빨강"
-          color="red-500"
+          color="red"
         />
         <FilterOption
           label="주황"
           icon={TbSquareRoundedFilled}
           field={'selectedColor'}
           value="주황"
-          color="orange-500"
+          color="orange"
         />
         <FilterOption
           label="노랑"
           icon={TbSquareRoundedFilled}
           field={'selectedColor'}
           value="노랑"
-          color="yellow-500"
+          color="yellow"
         />
         <FilterOption
           label="연두"
           icon={TbSquareRoundedFilled}
           field={'selectedColor'}
           value="연두"
-          color="lime-500"
+          color="lime"
         />
         <FilterOption
           label="초록"
           icon={TbSquareRoundedFilled}
           field={'selectedColor'}
           value="초록"
-          color="green-500"
+          color="green"
         />
         <FilterOption
           label="청록"
           icon={TbSquareRoundedFilled}
           field={'selectedColor'}
           value="청록"
-          color="teal-500"
+          color="teal"
         />
         <FilterOption
           label="파랑"
           icon={TbSquareRoundedFilled}
           field={'selectedColor'}
           value="파랑"
-          color="blue-500"
+          color="blue"
         />
       </div>
       <div className="flex flex-row gap-1">
@@ -69,28 +73,28 @@ const SelectedColor = () => {
           icon={TbSquareRoundedFilled}
           field="selectedColor"
           value="남색"
-          color="blue-900"
+          color="darkblue"
         />
         <FilterOption
           label="자주"
           icon={TbSquareRoundedFilled}
           field={'selectedColor'}
           value="자주"
-          color="fuchsia-500"
+          color="fuchsia"
         />
         <FilterOption
           label="보라"
           icon={TbSquareRoundedFilled}
           field={'selectedColor'}
           value="보라"
-          color="violet-500"
+          color="indigo"
         />
         <FilterOption
           label="회색"
           icon={TbSquareRoundedFilled}
           field={'selectedColor'}
           value="회색"
-          color="gray-500"
+          color="gray"
         />
         <FilterOption
           label="검정"
@@ -108,17 +112,17 @@ const SelectedColor = () => {
         />
         <FilterOption
           label="투명"
-          icon={TbSquareRoundedFilled}
+          icon={TbSquareRounded}
           field={'selectedColor'}
           value="투명"
-          color="gray-300"
+          color="white"
         />
         <FilterOption
           label="전체"
-          icon={TbSquareRoundedFilled}
+          icon={TbHelpSquareRoundedFilled}
           field={'selectedColor'}
           value="전체"
-          color="gray-300"
+          color="white"
         />
       </div>
     </div>


### PR DESCRIPTION
### 작업 개요
- 검색 필터링 옵션 중 색상이 반영 안되는 오류 해결.

### 연관된 이슈(optional)
- #24 

### 스크린샷(optional)
![image](https://github.com/user-attachments/assets/07a1d91d-e514-4d7c-8b91-9cc325525ca5)

### 해결(optional)
- 아이콘에 직접 인라인 스타일로 색상을 적용하는 코드로 변경함.

### 체크리스트
- [x] 코드가 정상적으로 작동하고 모든 테스트를 통과했나요?
