### PR TITLE
FE-Search02_Feat: 검색 필터링 기능 구현

### DIFF
--- a/client/src/apis/drugs.api.ts
+++ b/client/src/apis/drugs.api.ts
@@ -11,7 +11,7 @@ interface SearchParams {
   drugShape?: string;
   colorClass1?: string;
   colorClass2?: string;
-  linFront?: string;
+  lineFront?: string;
   lineBack?: string;
 }
 

--- a/client/src/apis/drugs.api.ts
+++ b/client/src/apis/drugs.api.ts
@@ -24,8 +24,11 @@ export const fetchDrugs = async (params: SearchParams) => {
     }
   });
 
+  const url = `/search?${query.toString()}`;
+  console.log(`Fetching drugs with URL: ${url}`);
+
   try {
-    const response = await httpClient.get(`/search?${query.toString()}`);
+    const response = await httpClient.get(url);
     return response.data;
   } catch (error) {
     console.error(

--- a/client/src/components/search/SearchFilter.tsx
+++ b/client/src/components/search/SearchFilter.tsx
@@ -46,7 +46,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ setResults }) => {
     drugShape: selectedShape.length > 0 ? selectedShape.join(',') : undefined,
     colorClass1: selectedColor.length > 0 ? selectedColor[0] : undefined,
     colorClass2: selectedColor.length > 1 ? selectedColor[1] : undefined,
-    linFront: selectedLine.length > 0 ? selectedLine[0] : undefined,
+    lineFront: selectedLine.length > 0 ? selectedLine[0] : undefined,
     lineBack: selectedLine.length > 1 ? selectedLine[1] : undefined,
   };
 

--- a/client/src/components/search/SearchFilter.tsx
+++ b/client/src/components/search/SearchFilter.tsx
@@ -5,8 +5,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../store';
 import {
   resetFilters,
-  setSearchIdentification1,
-  setSearchIdentification2,
+  setPrintFront,
+  setPrintBack,
 } from '../../store/slices/filterSlice';
 import SelectedForm from './filterOption/SelectedForm';
 import SelectedLine from './filterOption/SelectedLine';
@@ -23,8 +23,8 @@ interface SearchFilterProps {
 const SearchFilter: React.FC<SearchFilterProps> = ({ setResults }) => {
   const dispatch = useDispatch();
   const {
-    searchIdentification1,
-    searchIdentification2,
+    printFront,
+    printBack,
     selectedForm,
     selectedLine,
     selectedShape,
@@ -40,18 +40,21 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ setResults }) => {
     ingrEngName: selectedDrugCategory === '성분명' ? searchDrug : undefined,
     ingrKorName: selectedDrugCategory === '성분명' ? searchDrug : undefined,
     efcyQesitm: selectedDrugCategory === '효능효과' ? searchDrug : undefined,
-    identification1: searchIdentification1,
-    identification2: searchIdentification2,
-    form: selectedForm,
-    line: selectedLine,
-    shape: selectedShape,
-    color: selectedColor,
+    printFront: printFront || undefined,
+    printBack: printBack || undefined,
+    dosageForm: selectedForm.length > 0 ? selectedForm.join(',') : undefined,
+    drugShape: selectedShape.length > 0 ? selectedShape.join(',') : undefined,
+    colorClass1: selectedColor.length > 0 ? selectedColor[0] : undefined,
+    colorClass2: selectedColor.length > 1 ? selectedColor[1] : undefined,
+    linFront: selectedLine.length > 0 ? selectedLine[0] : undefined,
+    lineBack: selectedLine.length > 1 ? selectedLine[1] : undefined,
   };
 
   const applyFilters = async () => {
     setResults([]);
     try {
       const data = await fetchDrugs(filters);
+
       dispatch(setSearchResults(data));
       setResults(data);
       console.log(filters);
@@ -62,6 +65,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ setResults }) => {
 
   const handleResetClick = () => {
     dispatch(resetFilters());
+    setResults([]);
   };
 
   return (
@@ -70,14 +74,14 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ setResults }) => {
         <div className="flex flex-col w-full gap-1">
           <p className="font-semibold">식별문자</p>
           <Input
-            value={searchIdentification1}
+            value={printFront}
             placeholder={'문자1'}
-            onChange={(e) => dispatch(setSearchIdentification1(e.target.value))}
+            onChange={(e) => dispatch(setPrintFront(e.target.value))}
           />
           <Input
-            value={searchIdentification2}
+            value={printBack}
             placeholder={'문자2'}
-            onChange={(e) => dispatch(setSearchIdentification2(e.target.value))}
+            onChange={(e) => dispatch(setPrintBack(e.target.value))}
           />
         </div>
         <div>

--- a/client/src/components/search/SearchFilter.tsx
+++ b/client/src/components/search/SearchFilter.tsx
@@ -75,12 +75,12 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ setResults }) => {
           <p className="font-semibold">식별문자</p>
           <Input
             value={printFront}
-            placeholder={'문자1'}
+            placeholder={'문자1(앞)'}
             onChange={(e) => dispatch(setPrintFront(e.target.value))}
           />
           <Input
             value={printBack}
-            placeholder={'문자2'}
+            placeholder={'문자2(뒤)'}
             onChange={(e) => dispatch(setPrintBack(e.target.value))}
           />
         </div>

--- a/client/src/components/search/filterOption/FilterOption.tsx
+++ b/client/src/components/search/filterOption/FilterOption.tsx
@@ -24,9 +24,9 @@ const FilterOption: React.FC<FilterOptionProps> = ({
   const iconStyle = color ? { color } : {};
 
   const handleClick = () => {
-    if (value === 'All') {
+    if (value === '') {
       selectedValues.forEach((v) => {
-        if (v !== 'All') {
+        if (v !== '') {
           dispatch(toggleSelection({ field, value: v }));
         }
       });
@@ -34,8 +34,8 @@ const FilterOption: React.FC<FilterOptionProps> = ({
         dispatch(toggleSelection({ field, value }));
       }
     } else {
-      if (selectedValues.includes('All')) {
-        dispatch(toggleSelection({ field, value: 'All' }));
+      if (selectedValues.includes('')) {
+        dispatch(toggleSelection({ field, value: '' }));
       }
       dispatch(toggleSelection({ field, value }));
     }

--- a/client/src/components/search/filterOption/FilterOption.tsx
+++ b/client/src/components/search/filterOption/FilterOption.tsx
@@ -8,7 +8,6 @@ interface FilterOptionProps {
   field: 'selectedForm' | 'selectedLine' | 'selectedShape' | 'selectedColor';
   value: string;
   color?: string;
-  excludeValues?: string[];
 }
 
 const FilterOption: React.FC<FilterOptionProps> = ({
@@ -35,7 +34,6 @@ const FilterOption: React.FC<FilterOptionProps> = ({
         dispatch(toggleSelection({ field, value }));
       }
     } else {
-      // 특정 필터 선택 시
       if (selectedValues.includes('All')) {
         dispatch(toggleSelection({ field, value: 'All' }));
       }

--- a/client/src/components/search/filterOption/FilterOption.tsx
+++ b/client/src/components/search/filterOption/FilterOption.tsx
@@ -8,6 +8,7 @@ interface FilterOptionProps {
   field: 'selectedForm' | 'selectedLine' | 'selectedShape' | 'selectedColor';
   value: string;
   color?: string;
+  excludeValues?: string[];
 }
 
 const FilterOption: React.FC<FilterOptionProps> = ({
@@ -18,15 +19,33 @@ const FilterOption: React.FC<FilterOptionProps> = ({
   color,
 }) => {
   const dispatch = useDispatch();
-  const isSelected = useSelector((state: RootState) =>
-    state.filter[field].includes(value)
-  );
+  const selectedValues = useSelector((state: RootState) => state.filter[field]);
+  const isSelected = selectedValues.includes(value);
 
   const iconStyle = color ? { color } : {};
 
+  const handleClick = () => {
+    if (value === 'All') {
+      selectedValues.forEach((v) => {
+        if (v !== 'All') {
+          dispatch(toggleSelection({ field, value: v }));
+        }
+      });
+      if (!isSelected) {
+        dispatch(toggleSelection({ field, value }));
+      }
+    } else {
+      // 특정 필터 선택 시
+      if (selectedValues.includes('All')) {
+        dispatch(toggleSelection({ field, value: 'All' }));
+      }
+      dispatch(toggleSelection({ field, value }));
+    }
+  };
+
   return (
     <div
-      onClick={() => dispatch(toggleSelection({ field, value }))}
+      onClick={handleClick}
       className={`py-2 px-4 m-1 items-center text-center shadow-sm shadow-medicinePoint justify-center rounded-lg  hover:bg-medicinePositive cursor-pointer ${isSelected ? 'bg-medicinePoint text-medicineSecondary' : 'bg-medicineSecondary'}`}
       role="button"
       aria-label={label}

--- a/client/src/components/search/filterOption/SelectedColor.tsx
+++ b/client/src/components/search/filterOption/SelectedColor.tsx
@@ -11,13 +11,6 @@ const SelectedColor = () => {
       <p className="pb-1 font-semibold">색상</p>
       <div className="flex flex-row justify-center min-w-full gap-1 p-1 pt-2 border-2 border-b-0 rounded-t-lg border-medicineSecondary bg-medicinePrimary">
         <FilterOption
-          label="분홍"
-          icon={TbSquareRoundedFilled}
-          field="selectedColor"
-          value="분홍"
-          color="pink"
-        />
-        <FilterOption
           label="빨강"
           icon={TbSquareRoundedFilled}
           field={'selectedColor'}
@@ -52,8 +45,6 @@ const SelectedColor = () => {
           value="초록"
           color="green"
         />
-      </div>
-      <div className="flex flex-row justify-center min-w-full gap-1 p-1 border-2 border-medicineSecondary bg-medicinePrimary">
         <FilterOption
           label="청록"
           icon={TbSquareRoundedFilled}
@@ -61,26 +52,14 @@ const SelectedColor = () => {
           value="청록"
           color="teal"
         />
+      </div>
+      <div className="flex flex-row justify-center min-w-full gap-1 p-1 border-2 border-medicineSecondary bg-medicinePrimary">
         <FilterOption
           label="파랑"
           icon={TbSquareRoundedFilled}
           field={'selectedColor'}
           value="파랑"
           color="blue"
-        />
-        <FilterOption
-          label="남색"
-          icon={TbSquareRoundedFilled}
-          field="selectedColor"
-          value="남색"
-          color="darkblue"
-        />
-        <FilterOption
-          label="자주"
-          icon={TbSquareRoundedFilled}
-          field={'selectedColor'}
-          value="자주"
-          color="fuchsia"
         />
         <FilterOption
           label="보라"
@@ -90,14 +69,35 @@ const SelectedColor = () => {
           color="indigo"
         />
         <FilterOption
+          label="자주"
+          icon={TbSquareRoundedFilled}
+          field={'selectedColor'}
+          value="자주"
+          color="fuchsia"
+        />
+        <FilterOption
+          label="분홍"
+          icon={TbSquareRoundedFilled}
+          field="selectedColor"
+          value="분홍"
+          color="pink"
+        />
+        <FilterOption
+          label="갈색"
+          icon={TbSquareRoundedFilled}
+          field="selectedColor"
+          value="갈색"
+          color="brown"
+        />
+      </div>
+      <div className="flex flex-row justify-center min-w-full gap-1 p-1 pb-2 border-2 border-t-0 rounded-b-lg bg-medicinePrimary border-medicineSecondary">
+        <FilterOption
           label="회색"
           icon={TbSquareRoundedFilled}
           field={'selectedColor'}
           value="회색"
           color="gray"
         />
-      </div>
-      <div className="flex flex-row justify-center min-w-full gap-1 p-1 pb-2 border-2 border-t-0 rounded-b-lg bg-medicinePrimary border-medicineSecondary">
         <FilterOption
           label="검정"
           icon={TbSquareRoundedFilled}
@@ -123,7 +123,7 @@ const SelectedColor = () => {
           label="전체"
           icon={TbHelpSquareRoundedFilled}
           field={'selectedColor'}
-          value="전체"
+          value=""
           color="white"
         />
       </div>

--- a/client/src/components/search/filterOption/SelectedForm.tsx
+++ b/client/src/components/search/filterOption/SelectedForm.tsx
@@ -1,6 +1,11 @@
 import FilterOption from './FilterOption';
 import { CiTablets1 } from 'react-icons/ci';
-import { GiMedicinePills, GiPill, GiPillDrop } from 'react-icons/gi';
+import {
+  GiMedicinePills,
+  GiMedicines,
+  GiPill,
+  GiPillDrop,
+} from 'react-icons/gi';
 
 const SelectedForm = () => {
   return (
@@ -33,7 +38,7 @@ const SelectedForm = () => {
         />
         <FilterOption
           label="전체"
-          icon={GiMedicinePills}
+          icon={GiMedicines}
           field="selectedForm"
           value="전체"
         />

--- a/client/src/components/search/filterOption/SelectedForm.tsx
+++ b/client/src/components/search/filterOption/SelectedForm.tsx
@@ -1,6 +1,6 @@
 import FilterOption from './FilterOption';
 import { CiTablets1 } from 'react-icons/ci';
-import { GiMedicinePills, GiMedicines, GiPill } from 'react-icons/gi';
+import { GiMedicines, GiPill } from 'react-icons/gi';
 
 const SelectedForm = () => {
   return (
@@ -20,16 +20,10 @@ const SelectedForm = () => {
           value="Capsule"
         />
         <FilterOption
-          label="기타"
+          label="전체"
           icon={GiMedicines}
           field="selectedForm"
-          value="ETC"
-        />
-        <FilterOption
-          label="전체"
-          icon={GiMedicinePills}
-          field="selectedForm"
-          value="All"
+          value=""
         />
       </div>
     </div>

--- a/client/src/components/search/filterOption/SelectedForm.tsx
+++ b/client/src/components/search/filterOption/SelectedForm.tsx
@@ -11,13 +11,13 @@ const SelectedForm = () => {
           label="정제"
           icon={CiTablets1}
           field="selectedForm"
-          value="Tablet"
+          value="tablet"
         />
         <FilterOption
           label="캡슐"
           icon={GiPill}
           field="selectedForm"
-          value="Capsule"
+          value="capsule"
         />
         <FilterOption
           label="전체"

--- a/client/src/components/search/filterOption/SelectedForm.tsx
+++ b/client/src/components/search/filterOption/SelectedForm.tsx
@@ -1,11 +1,6 @@
 import FilterOption from './FilterOption';
 import { CiTablets1 } from 'react-icons/ci';
-import {
-  GiMedicinePills,
-  GiMedicines,
-  GiPill,
-  GiPillDrop,
-} from 'react-icons/gi';
+import { GiMedicinePills, GiMedicines, GiPill } from 'react-icons/gi';
 
 const SelectedForm = () => {
   return (
@@ -16,31 +11,25 @@ const SelectedForm = () => {
           label="정제"
           icon={CiTablets1}
           field="selectedForm"
-          value="정제"
+          value="Tablet"
         />
         <FilterOption
-          label="경질캡슐"
+          label="캡슐"
           icon={GiPill}
           field="selectedForm"
-          value="경질캡슐"
-        />
-        <FilterOption
-          label="연질캡슐"
-          icon={GiPillDrop}
-          field="selectedForm"
-          value="연질캡슐"
+          value="Capsule"
         />
         <FilterOption
           label="기타"
-          icon={GiMedicinePills}
+          icon={GiMedicines}
           field="selectedForm"
-          value="기타"
+          value="ETC"
         />
         <FilterOption
           label="전체"
-          icon={GiMedicines}
+          icon={GiMedicinePills}
           field="selectedForm"
-          value="전체"
+          value="All"
         />
       </div>
     </div>

--- a/client/src/components/search/filterOption/SelectedLine.tsx
+++ b/client/src/components/search/filterOption/SelectedLine.tsx
@@ -1,10 +1,4 @@
-import {
-  FiCircle,
-  FiHelpCircle,
-  FiMinusCircle,
-  FiPlusCircle,
-  FiStopCircle,
-} from 'react-icons/fi';
+import { FiHelpCircle, FiMinusCircle, FiPlusCircle } from 'react-icons/fi';
 import FilterOption from './FilterOption';
 
 const SelectedLine = () => {
@@ -13,34 +7,22 @@ const SelectedLine = () => {
       <p className="pb-1 font-semibold">분할선</p>
       <div className="flex flex-row justify-center min-w-full gap-1 p-1 py-2 border-2 rounded-lg border-medicineSecondary bg-medicinePrimary">
         <FilterOption
-          label="없음"
-          icon={FiCircle}
-          field="selectedLine"
-          value="없음"
-        />
-        <FilterOption
           label="(+)형"
           icon={FiPlusCircle}
           field="selectedLine"
-          value="(+)형"
+          value="+"
         />
         <FilterOption
           label="(-)형"
           icon={FiMinusCircle}
           field="selectedLine"
-          value="(-)형"
-        />
-        <FilterOption
-          label="기타"
-          icon={FiStopCircle}
-          field="selectedLine"
-          value="기타"
+          value="-"
         />
         <FilterOption
           label="전체"
           icon={FiHelpCircle}
           field="selectedLine"
-          value="전체"
+          value=""
         />
       </div>
     </div>

--- a/client/src/components/search/filterOption/SelectedLine.tsx
+++ b/client/src/components/search/filterOption/SelectedLine.tsx
@@ -1,4 +1,10 @@
-import { FiCircle, FiMinusCircle, FiPlusCircle } from 'react-icons/fi';
+import {
+  FiCircle,
+  FiHelpCircle,
+  FiMinusCircle,
+  FiPlusCircle,
+  FiStopCircle,
+} from 'react-icons/fi';
 import FilterOption from './FilterOption';
 
 const SelectedLine = () => {
@@ -26,13 +32,13 @@ const SelectedLine = () => {
         />
         <FilterOption
           label="기타"
-          icon={FiCircle}
+          icon={FiStopCircle}
           field="selectedLine"
           value="기타"
         />
         <FilterOption
           label="전체"
-          icon={FiCircle}
+          icon={FiHelpCircle}
           field="selectedLine"
           value="전체"
         />

--- a/client/src/components/search/filterOption/SelectedShape.tsx
+++ b/client/src/components/search/filterOption/SelectedShape.tsx
@@ -90,7 +90,7 @@ const SelectedShape = () => {
           label="전체"
           icon={FiHelpCircle}
           field="selectedShape"
-          value="전체"
+          value=""
         />
       </div>
     </div>

--- a/client/src/components/search/filterOption/SelectedShape.tsx
+++ b/client/src/components/search/filterOption/SelectedShape.tsx
@@ -11,6 +11,7 @@ import {
   TbTriangle,
 } from 'react-icons/tb';
 import FilterOption from './FilterOption';
+import { FiHelpCircle, FiStopCircle } from 'react-icons/fi';
 
 const SelectedShape = () => {
   return (
@@ -81,13 +82,13 @@ const SelectedShape = () => {
         />
         <FilterOption
           label="기타"
-          icon={TbCircle}
+          icon={FiStopCircle}
           field="selectedShape"
           value="기타"
         />
         <FilterOption
           label="전체"
-          icon={TbCircle}
+          icon={FiHelpCircle}
           field="selectedShape"
           value="전체"
         />

--- a/client/src/store/slices/filterSlice.ts
+++ b/client/src/store/slices/filterSlice.ts
@@ -1,9 +1,8 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 type FilterState = {
-  searchData: string;
-  searchIdentification1: string;
-  searchIdentification2: string;
+  printFront: string;
+  printBack: string;
   selectedForm: string[];
   selectedLine: string[];
   selectedShape: string[];
@@ -11,9 +10,8 @@ type FilterState = {
 };
 
 const initialState: FilterState = {
-  searchData: '',
-  searchIdentification1: '',
-  searchIdentification2: '',
+  printFront: '',
+  printBack: '',
   selectedForm: ['전체'],
   selectedLine: ['전체'],
   selectedShape: ['전체'],
@@ -24,11 +22,11 @@ const filterSlice = createSlice({
   name: 'filter',
   initialState,
   reducers: {
-    setSearchIdentification1: (state, action: PayloadAction<string>) => {
-      state.searchIdentification1 = action.payload;
+    setPrintFront: (state, action: PayloadAction<string>) => {
+      state.printFront = action.payload;
     },
-    setSearchIdentification2: (state, action: PayloadAction<string>) => {
-      state.searchIdentification2 = action.payload;
+    setPrintBack: (state, action: PayloadAction<string>) => {
+      state.printBack = action.payload;
     },
     setSelectedForm: (state, action: PayloadAction<string[]>) => {
       state.selectedForm = action.payload;
@@ -48,7 +46,7 @@ const filterSlice = createSlice({
       action: PayloadAction<{
         field: keyof Omit<
           FilterState,
-          'searchData' | 'searchIdentification1' | 'searchIdentification2'
+          'searchData' | 'printFront' | 'printBack'
         >;
         value: string;
       }>
@@ -73,8 +71,8 @@ const filterSlice = createSlice({
 });
 
 export const {
-  setSearchIdentification1,
-  setSearchIdentification2,
+  setPrintFront,
+  setPrintBack,
   setSelectedForm,
   setSelectedLine,
   setSelectedShape,

--- a/client/src/store/slices/filterSlice.ts
+++ b/client/src/store/slices/filterSlice.ts
@@ -14,10 +14,10 @@ const initialState: FilterState = {
   searchData: '',
   searchIdentification1: '',
   searchIdentification2: '',
-  selectedForm: [],
-  selectedLine: [],
-  selectedShape: [],
-  selectedColor: [],
+  selectedForm: ['전체'],
+  selectedLine: ['전체'],
+  selectedShape: ['전체'],
+  selectedColor: ['전체'],
 };
 
 const filterSlice = createSlice({
@@ -55,10 +55,18 @@ const filterSlice = createSlice({
     ) => {
       const { field, value } = action.payload;
       const currentValues = state[field] as string[];
-      if (currentValues.includes(value)) {
-        state[field] = currentValues.filter((v) => v !== value);
+      if (value === '전체') {
+        state[field] = ['전체'];
       } else {
-        state[field] = [...currentValues, value];
+        if (currentValues.includes('전체')) {
+          state[field] = [value];
+        } else {
+          if (currentValues.includes(value)) {
+            state[field] = currentValues.filter((v) => v !== value);
+          } else {
+            state[field] = [...currentValues, value];
+          }
+        }
       }
     },
   },

--- a/client/src/store/slices/filterSlice.ts
+++ b/client/src/store/slices/filterSlice.ts
@@ -12,10 +12,10 @@ type FilterState = {
 const initialState: FilterState = {
   printFront: '',
   printBack: '',
-  selectedForm: ['전체'],
-  selectedLine: ['전체'],
-  selectedShape: ['전체'],
-  selectedColor: ['전체'],
+  selectedForm: [''],
+  selectedLine: [''],
+  selectedShape: [''],
+  selectedColor: [''],
 };
 
 const filterSlice = createSlice({
@@ -53,10 +53,10 @@ const filterSlice = createSlice({
     ) => {
       const { field, value } = action.payload;
       const currentValues = state[field] as string[];
-      if (value === '전체') {
-        state[field] = ['전체'];
+      if (value === '') {
+        state[field] = [''];
       } else {
-        if (currentValues.includes('전체')) {
+        if (currentValues.includes('')) {
           state[field] = [value];
         } else {
           if (currentValues.includes(value)) {

--- a/client/src/types/drug.type.ts
+++ b/client/src/types/drug.type.ts
@@ -10,7 +10,7 @@ export interface DrugData {
   drugShape: string; // 모양
   colorClass1: string; // 색상
   colorClass2: string;
-  linFront: string; // 분할선(앞)
+  lineFront: string; // 분할선(앞)
   lineBack: string; // 분할선(뒤)
 }
 


### PR DESCRIPTION
### 작업 개요
- 검색 필터링 기능 구현

### 연관된 이슈(optional)
- #21 

### 스크린샷(optional)
- **효능효과:두통 / 식별문자: 분할선 / 모양: 원형 / 색상: 노랑 으로 검색한 결과**
  ![image](https://github.com/user-attachments/assets/fb3ef3b6-ecf3-437c-b080-4d13bc73f1c8)
- **모양: 장방형 / 색상: 빨강 으로 검색한 결과**
![image](https://github.com/user-attachments/assets/7658f5e0-dda5-4fb6-9fb6-d03c3d42e60a)

### 기타 참고 사항(optional)
- 공공API를 활용한 drug DB가 가지고 있는 의약품 정보가 서로 달라 빈 데이터가 많음.
- 특히 제형이랑 분할선이 데이터가 없는 경우가 많아, 두 옵션만 기본(전체)으로 두고 하면 구현 잘됨.
- 분할선은 앞,뒤( {-,+}, {+,-}) 선택 순서에 따라 결과가 달라져 추후 시간이 날 때 수정 필요할 듯.

### 체크리스트
- [x] 코드가 정상적으로 작동하고 모든 테스트를 통과했나요?
- [x] 필요한 경우, 팀원에게 알렸나요?
