### PR TITLE
FE-Search01_Feat: MainPage SearchInput

### DIFF
--- a/client/src/components/common/Footer.tsx
+++ b/client/src/components/common/Footer.tsx
@@ -6,7 +6,7 @@ const Footer = () => {
   };
 
   return (
-    <div className="flex flex-row items-center justify-end w-auto px-2 text-sm bg-blue-100 h-14">
+    <div className="flex flex-row items-center justify-end w-auto px-2 text-sm bg-blue-100 h-11">
       <div className="text-xs text-right text-medicineFontBlue">
         ⓒ 2024. Team.medicineWeb. All rights reserved. <br />
       </div>

--- a/client/src/components/common/Header.tsx
+++ b/client/src/components/common/Header.tsx
@@ -31,7 +31,7 @@ const Header = () => {
   };
 
   return (
-    <div className="flex flex-row items-center justify-between w-auto px-2 bg-blue-100 h-14">
+    <div className="flex flex-row items-center justify-between w-auto px-2 bg-blue-100 h-11">
       <a href="/">
         <img src={Title1} alt="medicineWebTitle" className="w-48" />
       </a>

--- a/client/src/components/common/Pagination.tsx
+++ b/client/src/components/common/Pagination.tsx
@@ -40,7 +40,7 @@ const Pagination = ({ totalItems }: { totalItems: number }) => {
   };
 
   return (
-    <div className="flex items-center justify-center gap-3 p-4 m-4 text-5xl text-medicinePositive">
+    <div className="flex items-center justify-center gap-3 p-1 m-2 text-3xl text-medicinePositive">
       <div className="flex">
         <TbSquareChevronsLeftFilled
           onClick={goToFirstPage}

--- a/client/src/components/reference/Reference.tsx
+++ b/client/src/components/reference/Reference.tsx
@@ -60,18 +60,24 @@ const Reference: React.FC<ReferenceProps> = ({ data }) => {
   };
 
   return (
-    <div className="max-w-screen-lg p-4 mx-auto text-xs bg-medicineNeutral whitespace-nowrap">
-      <p className="flex items-center gap-1 my-4 text-base font-semibold text-left">
-        <FaSearch />
-        검색 결과
-      </p>
+    <div className="px-4 py-2 mx-auto text-xs rounded-lg bg-medicineNeutral whitespace-nowrap">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1 pb-2 text-base font-semibold text-left">
+          <FaSearch />
+          검색 결과
+        </div>
+        {selectedDrugDetail && (
+          <ReferenceDetail drug={selectedDrugDetail} onClose={handleClose} />
+        )}
+        <Pagination totalItems={data.length} />
+      </div>
       <table className="w-full border-2 table-fixed border-medicinePositive">
         <thead>
-          <tr className="text-base border-b-2 border-medicinePositive bg-medicinePrimary">
+          <tr className="font-bold border-b-2 border-medicinePositive bg-medicinePrimary">
             <th className="w-10 border-r border-medicinePositive">No.</th>
             <th className="w-32 ">이미지</th>
             <th className="w-24 border-x border-medicinePositive">의약품명</th>
-            <th className="w-32 ">성분</th>
+            <th className="w-20 ">성분</th>
             <th className="border-l w-80 border-medicinePositive">효능•효과</th>
           </tr>
         </thead>
@@ -82,41 +88,41 @@ const Reference: React.FC<ReferenceProps> = ({ data }) => {
               className="border-b cursor-pointer border-medicinePositive hover:bg-medicinePrimary"
               onClick={() => handleRowClick(drug.drugId)}
             >
-              <td className="p-2 border-r border-medicinePositive">
+              <td className="px-1 border-r border-medicinePositive">
                 {startIndex + index + 1}
               </td>
-              <td className="flex justify-center m-2">
+              <td className="flex justify-center px-1 m-1">
                 <img
                   src={drug.itemImage}
                   alt={drug.itemName}
-                  className="object-contain w-32 border-2 rounded-lg border-medicinePositive"
+                  className="object-contain w-24 border-2 rounded-lg border-medicinePositive"
                 />
               </td>
-              <td className="p-2 break-words whitespace-normal border-x border-medicinePositive">
+              <td className="px-1 break-words whitespace-normal border-x border-medicinePositive">
                 {drug.itemName}
               </td>
-              <td className="p-2 break-words whitespace-normal border-x border-medicinePositive">
+              <td className="px-1 break-words whitespace-normal border-x border-medicinePositive">
                 {drug.ingrEngName ? (
                   drug.ingrEngName
                 ) : (
-                  <img src={unprepared} alt="unprepared" className="w-28" />
+                  <img src={unprepared} alt="unprepared" className="w-20" />
                 )}
               </td>
-              <td className="p-3 break-words whitespace-normal border-l border-medicinePositive">
+              <td className="px-3 break-words whitespace-normal border-l border-medicinePositive">
                 {drug.efcyQesitm ? (
-                  cutPrefixSuffix(drug.efcyQesitm)
+                  cutPrefixSuffix(drug.efcyQesitm).length > 80 ? (
+                    `${cutPrefixSuffix(drug.efcyQesitm).slice(0, 80)}...`
+                  ) : (
+                    cutPrefixSuffix(drug.efcyQesitm)
+                  )
                 ) : (
-                  <img src={unprepared} alt="unprepared" className="w-28" />
+                  <img src={unprepared} alt="unprepared" className="w-20" />
                 )}
               </td>
             </tr>
           ))}
         </tbody>
       </table>
-      {selectedDrugDetail && (
-        <ReferenceDetail drug={selectedDrugDetail} onClose={handleClose} />
-      )}
-      <Pagination totalItems={data.length} />
     </div>
   );
 };

--- a/client/src/components/reference/ReferenceDetail.tsx
+++ b/client/src/components/reference/ReferenceDetail.tsx
@@ -1,5 +1,5 @@
 import { FiX } from 'react-icons/fi';
-import { HiOutlineStar, HiStar } from 'react-icons/hi2';
+import { HiOutlineStar /* HiStar */ } from 'react-icons/hi2';
 import { DrugData } from '../../types/drug.type';
 import unprepared from '../../assets/images/Unprepared.png';
 
@@ -35,7 +35,7 @@ const ReferenceDetail: React.FC<ReferenceDetailProps> = ({ drug, onClose }) => {
           <div className="flex flex-row items-center gap-8">
             <img
               src={drug.itemImage}
-              className="h-32 border-2 w-60 border-medicineSecondary rounded-3xl bg-medicinePrimary"
+              className="h-40 border-2 w-72 border-medicineSecondary rounded-3xl bg-medicinePrimary"
               alt={drug.itemName}
             />
             <div>

--- a/client/src/components/reference/ReferenceEmpty.tsx
+++ b/client/src/components/reference/ReferenceEmpty.tsx
@@ -1,10 +1,10 @@
-import Logo3 from '../../assets/images/Logo3.png';
+import Logo4 from '../../assets/images/Logo4.png';
 
 const ReferenceEmpty = () => {
   return (
-    <div className="flex flex-col items-center justify-center m-4 text-center bg-medicineNeutral whitespace-nowrap">
-      <img src={Logo3} className="w-auto" />
-      <p className="px-10 text-2xl font-thin text-medicinePoint">
+    <div className="flex flex-col items-center justify-center py-48 text-xs rounded-lg pb-52 bg-medicineNeutral whitespace-nowrap">
+      <img src={Logo4} className="w-72" />
+      <p className="px-10 text-lg font-thin text-medicinePoint">
         해당하는 검색 결과가 없습니다. <br />
         다른 검색어를 입력해주시거나 식별 검색을 이용해 주세요.
       </p>

--- a/client/src/components/search/SearchBox.tsx
+++ b/client/src/components/search/SearchBox.tsx
@@ -87,7 +87,7 @@ const SearchBox: React.FC<SearchBoxProps> = ({ setResults }) => {
   };
 
   return (
-    <div className="flex flex-row items-center justify-between gap-4 px-5 pt-5 my-5">
+    <div className="flex flex-row items-center justify-between gap-4 px-5 pt-2">
       <ul
         onClick={() => setView(!view)}
         className="flex flex-col items-center text-sm"

--- a/client/src/components/search/SearchFilter.tsx
+++ b/client/src/components/search/SearchFilter.tsx
@@ -68,8 +68,8 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ setResults }) => {
   };
 
   return (
-    <div className="p-5 m-5 border-t-2 border-medicinePositive">
-      <div className="flex items-center justify-between gap-6 p-2">
+    <div className="p-1 m-2 border-t-2 border-medicinePositive">
+      <div className="flex items-center justify-between gap-6 p-1">
         <div className="flex flex-col w-full gap-1">
           <p className="font-semibold">식별문자</p>
           <Input
@@ -92,11 +92,13 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ setResults }) => {
           />
         </div>
       </div>
-      <SelectedForm />
-      <SelectedLine />
+      <div className="flex flex-row justify-between">
+        <SelectedForm />
+        <SelectedLine />
+      </div>
       <SelectedShape />
       <SelectedColor />
-      <div className="flex justify-end gap-2 pt-2">
+      <div className="flex justify-end gap-2 p-2 pb-5">
         <PositiveButton onClick={applyFilters}>확인</PositiveButton>
         <NegativeButton onClick={handleResetClick}>초기화</NegativeButton>
       </div>

--- a/client/src/components/search/filterOption/FilterOption.tsx
+++ b/client/src/components/search/filterOption/FilterOption.tsx
@@ -44,11 +44,11 @@ const FilterOption: React.FC<FilterOptionProps> = ({
   return (
     <div
       onClick={handleClick}
-      className={`py-2 px-4 m-1 items-center text-center shadow-sm shadow-medicinePoint justify-center rounded-lg  hover:bg-medicinePositive cursor-pointer ${isSelected ? 'bg-medicinePoint text-medicineSecondary' : 'bg-medicineSecondary'}`}
+      className={`px-2 m-1 items-center text-center shadow-sm shadow-medicinePoint justify-center rounded-lg  hover:bg-medicinePositive cursor-pointer ${isSelected ? 'bg-medicinePoint text-medicineSecondary' : 'bg-medicineSecondary'}`}
       role="button"
       aria-label={label}
     >
-      <Icon className="m-1 text-3xl" style={iconStyle} />
+      <Icon className="m-1 text-2xl" style={iconStyle} />
       {label}
     </div>
   );

--- a/client/src/components/search/filterOption/SelectedColor.tsx
+++ b/client/src/components/search/filterOption/SelectedColor.tsx
@@ -7,7 +7,7 @@ import FilterOption from './FilterOption';
 
 const SelectedColor = () => {
   return (
-    <div className="flex flex-col p-2">
+    <div className="flex flex-col p-1">
       <p className="pb-1 font-semibold">색상</p>
       <div className="flex flex-row justify-center min-w-full gap-1 p-1 pt-2 border-2 border-b-0 rounded-t-lg border-medicineSecondary bg-medicinePrimary">
         <FilterOption
@@ -52,8 +52,6 @@ const SelectedColor = () => {
           value="청록"
           color="teal"
         />
-      </div>
-      <div className="flex flex-row justify-center min-w-full gap-1 p-1 border-2 border-medicineSecondary bg-medicinePrimary">
         <FilterOption
           label="파랑"
           icon={TbSquareRoundedFilled}
@@ -68,6 +66,8 @@ const SelectedColor = () => {
           value="보라"
           color="indigo"
         />
+      </div>
+      <div className="flex flex-row justify-center min-w-full gap-1 p-1 border-2 rounded-b-lg border-medicineSecondary bg-medicinePrimary">
         <FilterOption
           label="자주"
           icon={TbSquareRoundedFilled}
@@ -89,8 +89,6 @@ const SelectedColor = () => {
           value="갈색"
           color="brown"
         />
-      </div>
-      <div className="flex flex-row justify-center min-w-full gap-1 p-1 pb-2 border-2 border-t-0 rounded-b-lg bg-medicinePrimary border-medicineSecondary">
         <FilterOption
           label="회색"
           icon={TbSquareRoundedFilled}

--- a/client/src/components/search/filterOption/SelectedForm.tsx
+++ b/client/src/components/search/filterOption/SelectedForm.tsx
@@ -6,7 +6,7 @@ const SelectedForm = () => {
   return (
     <div className="flex flex-col gap-1 p-2">
       <p className="pb-1 font-semibold">제형</p>
-      <div className="flex flex-row justify-center min-w-full gap-1 p-1 py-2 border-2 rounded-lg border-medicineSecondary bg-medicinePrimary">
+      <div className="flex flex-row justify-center min-w-full gap-1 px-6 py-2 border-2 rounded-lg border-medicineSecondary bg-medicinePrimary">
         <FilterOption
           label="정제"
           icon={CiTablets1}

--- a/client/src/components/search/filterOption/SelectedLine.tsx
+++ b/client/src/components/search/filterOption/SelectedLine.tsx
@@ -5,7 +5,7 @@ const SelectedLine = () => {
   return (
     <div className="flex flex-col gap-1 p-2">
       <p className="pb-1 font-semibold">분할선</p>
-      <div className="flex flex-row justify-center min-w-full gap-1 p-1 py-2 border-2 rounded-lg border-medicineSecondary bg-medicinePrimary">
+      <div className="flex flex-row justify-center min-w-full gap-1 px-6 py-2 border-2 rounded-lg border-medicineSecondary bg-medicinePrimary">
         <FilterOption
           label="(+)형"
           icon={FiPlusCircle}

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -5,9 +5,8 @@ import Input from '../components/common/Input';
 import { RootState } from '../store';
 import { setSearchDrugItem, setSearchResults } from '../store/slices/drugSlice';
 import { useNavigate } from 'react-router-dom';
-import React from 'react';
+import React, { useState } from 'react';
 import { PositiveButton } from '../components/common/Button';
-import { SearchBoxProps } from '../components/search/SearchBox';
 import { fetchDrugs } from '../apis/drugs.api';
 import { DrugData } from '../types/drug.type';
 import { LoginBox } from '../components/login/LoginBox';
@@ -16,7 +15,10 @@ import clsx from 'clsx';
 import { FiLogIn } from 'react-icons/fi';
 import { storeLogout } from '../store/slices/authSlice';
 
-const Main: React.FC<SearchBoxProps> = ({ setResults }) => {
+const Main: React.FC = () => {
+  const [results, setResults] = useState<DrugData[]>([]);
+  console.log(results);
+
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const { drug, auth } = useSelector((state: RootState) => state);
@@ -24,24 +26,24 @@ const Main: React.FC<SearchBoxProps> = ({ setResults }) => {
   const { isLogin } = auth;
 
   const handleSearch = async () => {
-    navigate('/search');
-
     if (!searchDrug) {
       return;
     }
 
     setResults([]);
     try {
-      const results = {
+      const searchResults = {
         [selectedDrugCategory]: searchDrug,
       };
-      const data = await fetchDrugs(results);
+      const data = await fetchDrugs(searchResults);
       const filteredData = data.filter((drug: DrugData) =>
         drug.itemName.includes(searchDrug)
       );
 
       dispatch(setSearchResults(filteredData));
       setResults(filteredData);
+
+      navigate('/search', { state: { results: filteredData } });
     } catch (error) {
       console.error(error);
     }
@@ -70,7 +72,7 @@ const Main: React.FC<SearchBoxProps> = ({ setResults }) => {
   };
 
   return (
-    <div className="min-h-screen flex bg-blue-100">
+    <div className="flex min-h-screen bg-blue-100">
       <div className="flex items-center justify-center pl-4 whitespace-nowrap">
         <div className="w-4/5 p-6">
           <img src={Logo1} alt="medicineWebLogo" />
@@ -85,7 +87,7 @@ const Main: React.FC<SearchBoxProps> = ({ setResults }) => {
           </div>
         </div>
       </div>
-      <div className="pr-4 flex flex-col items-center justify-center flex-grow">
+      <div className="flex flex-col items-center justify-center flex-grow pr-4">
         {!isLogin && <LoginBox />}
         <div
           className={clsx(
@@ -95,7 +97,7 @@ const Main: React.FC<SearchBoxProps> = ({ setResults }) => {
           )}
         >
           <div
-            className="flex items-center gap-2 cursor-pointer text-xl w-fit relative"
+            className="relative flex items-center gap-2 text-xl cursor-pointer w-fit"
             onClick={handleSearchClick}
           >
             <img
@@ -106,7 +108,7 @@ const Main: React.FC<SearchBoxProps> = ({ setResults }) => {
             <FaSearch /> {isLogin ? '상세 검색 하러 가기' : '상세 검색'}
           </div>
           <div
-            className="flex items-center gap-2 cursor-pointer text-xl relative"
+            className="relative flex items-center gap-2 text-xl cursor-pointer"
             onClick={handlePostsClick}
           >
             <img
@@ -119,7 +121,7 @@ const Main: React.FC<SearchBoxProps> = ({ setResults }) => {
           {isLogin && (
             <>
               <div
-                className="flex items-center gap-2 cursor-pointer text-xl relative"
+                className="relative flex items-center gap-2 text-xl cursor-pointer"
                 onClick={handleMyProfileClick}
               >
                 <img
@@ -130,7 +132,7 @@ const Main: React.FC<SearchBoxProps> = ({ setResults }) => {
                 <FaUserAlt /> 마이프로필
               </div>
               <div
-                className="flex items-center justify-center gap-2 cursor-pointer text-xl relative"
+                className="relative flex items-center justify-center gap-2 text-xl cursor-pointer"
                 onClick={handleLogout}
               >
                 <img

--- a/client/src/pages/Search.tsx
+++ b/client/src/pages/Search.tsx
@@ -13,13 +13,13 @@ const Search = () => {
   );
 
   return (
-    <div className="flex flex-col p-4 m-4">
-      <div className="flex justify-center">
-        <div className="flex flex-col max-w-screen-sm m-2 text-xs bg-medicineNeutral w-fit h-fit whitespace-nowrap">
+    <div className="flex flex-col items-center px-4 m-4">
+      <div className="flex justify-center flex-grow gap-6">
+        <div className="flex flex-col max-w-screen-sm text-xs rounded-lg shadow-md shadow-medicinePositive bg-medicineNeutral whitespace-nowrap w-fit h-fit">
           <SearchBox setResults={setResults} />
           <SearchFilter setResults={setResults} />
         </div>
-        <div className="m-4 text-center">
+        <div className="max-h-full overflow-y-auto text-center rounded-lg shadow-md shadow-medicinePositive w-fit h-fit">
           {results.length > 0 ? (
             <Reference data={results} />
           ) : (

--- a/client/src/pages/Search.tsx
+++ b/client/src/pages/Search.tsx
@@ -4,9 +4,13 @@ import SearchBox from '../components/search/SearchBox';
 import SearchFilter from '../components/search/SearchFilter';
 import { DrugData } from '../types/drug.type';
 import ReferenceEmpty from '../components/reference/ReferenceEmpty';
+import { useLocation } from 'react-router-dom';
 
 const Search = () => {
-  const [results, setResults] = useState<DrugData[]>([]);
+  const location = useLocation();
+  const [results, setResults] = useState<DrugData[]>(
+    location.state?.results || []
+  );
 
   return (
     <div className="flex flex-col p-4 m-4">


### PR DESCRIPTION
### 작업 개요
- 메인 페이지 검색 창 사용 시 useLocation을 이용해 검색한 데이터와 함께 /search 페이지로 이동.
- 검색한 데이터가 Reference에 넘어가 검색한 결과를 조회할 수 있게 함.

### 연관된 이슈(optional)
- #72 

### 스크린샷(optional)
- **메인 페이지**
  ![image](https://github.com/user-attachments/assets/eab31877-5339-48f1-995e-046ff89090a2)
- **검색 결과**
  ![image](https://github.com/user-attachments/assets/92402fa8-acb8-4740-a640-ea9b4c7cb409)

- **UI 개선**
  ![image](https://github.com/user-attachments/assets/fa3212ab-4bd2-48da-88f8-ca21db92760b)


### 체크리스트
- [x] 코드가 정상적으로 작동하고 모든 테스트를 통과했나요?
