### PR TITLE
FE-Fix: 회원 가입 시 중복 체크 안내가 부족한 부분 수정

### DIFF
--- a/client/src/pages/Join.tsx
+++ b/client/src/pages/Join.tsx
@@ -17,6 +17,10 @@ const Join = () => {
   const [passwordRe, setPasswordRe] = useState('');
   const [pwQuestion, setPwQuestion] = useState('');
   const [pwAnswer, setPwAnswer] = useState('');
+  const [errCheck, setErrCheck] = useState({
+    nickname: false,
+    id: false,
+  });
   const [wanrPasswordCheck, setWarnPasswordCheck] = useState('');
   const [warnNicknameCheck, setWarnNicknameCheck] = useState('');
   const [warnIdCheck, setWarnIdCheck] = useState('');
@@ -48,10 +52,11 @@ const Join = () => {
   };
   const handleJoin = (e: React.SyntheticEvent) => {
     e.preventDefault();
-    if (password !== passwordRe) {
-      // 버튼 클릭 시 일치 여부 확인
-      setWarnPasswordCheck('비밀번호가 일치하지 않습니다.');
-    } else {
+    if (
+      Object.values(errCheck).every((el) => el) &&
+      password !== '' &&
+      password === passwordRe
+    ) {
       setWarnPasswordCheck('');
       join({
         nickname,
@@ -64,6 +69,17 @@ const Join = () => {
       })
         .then(() => navigate('/login'))
         .catch((err) => console.log(err));
+    } else {
+      if (!errCheck.id || warnIdCheck.includes('중복')) {
+        setWarnIdCheck('중복을 확인해주세요');
+      }
+      if (!errCheck.nickname || warnNicknameCheck.includes('중복')) {
+        setWarnNicknameCheck('중복을 확인해주세요');
+      }
+      if (password !== passwordRe) {
+        // 버튼 클릭 시 일치 여부 확인
+        setWarnPasswordCheck('비밀번호가 일치하지 않습니다.');
+      }
     }
   };
   const handleNicknameCheck = () => {
@@ -71,12 +87,14 @@ const Join = () => {
       dupCheckNickname(nickname)
         .then(() => {
           setWarnNicknameCheck('사용 가능한 닉네임입니다');
+          setErrCheck({ ...errCheck, nickname: true });
         })
         .catch((err) => {
           if (err.response.status === 409) {
             setWarnNicknameCheck('중복된 닉네임입니다');
           }
           console.log(err);
+          setErrCheck({ ...errCheck, nickname: false });
         });
     } else {
       setWarnNicknameCheck('닉네임을 입력해주세요');
@@ -87,12 +105,14 @@ const Join = () => {
       dupCheckId(id)
         .then(() => {
           setWarnIdCheck('사용 가능한 아이디입니다');
+          setErrCheck({ ...errCheck, id: true });
         })
         .catch((err) => {
           if (err.response.status === 409) {
             setWarnIdCheck('중복된 아이디입니다');
           }
           console.log(err);
+          setErrCheck({ ...errCheck, id: false });
         });
     } else {
       setWarnIdCheck('아이디를 입력해주세요');


### PR DESCRIPTION
### 작업 개요
- 회원 가입 시 중복 체크를 하지 않고 가입을 하려고 하면 아무런 안내가 없다.
- 안내가 없는 경우 사용자가 왜 화면이 넘어가지 않는지에 대한 의문을 해결하기 위해 수정.
- 중복 체크를 하지 않고 회원 가입을 하는 경우 경고 문구에 중복을 확인해달라는 문구 추가.

### 연관된 이슈(optional)
- #28 

### 변경 사항(optional)

### 스크린샷(optional)

### 해결(optional)

### 기타 참고 사항(optional)

### 체크리스트
- [x] 중복 체크를 위한 경고 문구가 잘 나오는가?
